### PR TITLE
Add controller/view for new --restart-daemons

### DIFF
--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -1,0 +1,67 @@
+from .__meta__ import *
+from tracer.controllers.restart import RestartController
+
+
+class TestRestart(unittest.TestCase):
+
+	def test_no_sudo(self):
+		"""
+		RestartController requires root to run, no need to append executed helpers with sudo
+		"""
+		daemons = [
+			MockDaemon("sudo_restart", ["sudo service restart daemon"]),
+			MockDaemon("sudoless_restart", ["service restart daemon"]),
+			MockDaemon("daemon_containing_sudo", ["sudo service restart sudodaemon"])
+		]
+
+		# Assert that the call_helper never has to call sudo
+		def mock_call_helper(helper):
+			self.assertFalse(helper.startswith("sudo "))
+
+		RestartController.restart_daemons(daemons, call_helper=mock_call_helper)
+
+	def test_restart(self):
+		"""
+		Test the RestartController.restart_daemons method
+		"""
+		daemons = [
+			MockDaemon("should_succeed_one", ["sudo should_succeed"]),
+			MockDaemon("should_succeed_two", ["sudo should_succeed",
+											  "sudo second_unused_helper"]),
+			MockDaemon("should_fail", ["sudo fail"]),
+			MockDaemon("unrestartable", [])
+		]
+
+		# Emulate service restarting
+		def mock_call_helper(helper):
+			return helper == "should_succeed"
+
+		# Restart each of the daemons and get the result dict
+		restarted_daemons = RestartController.restart_daemons(daemons, call_helper=mock_call_helper)
+
+		# Test that each daemon has a result
+		self.assertEquals(len(daemons), len(restarted_daemons))
+
+		# Test that each daemon was correctly reported as restarted, failed or un-restartabe
+		for daemon, result in restarted_daemons.items():
+			if "succeed" in daemon.name():
+				self.assertTrue(result)
+			elif "fail" in daemon.name():
+				self.assertFalse(result)
+			else:
+				self.assertTrue(result is None)
+
+
+class MockDaemon(object):
+	_name = None
+	_helpers = []
+
+	def __init__(self, name, helpers):
+		self._name = name
+		self._helpers = helpers
+
+	def name(self):
+		return self._name
+
+	def helpers(self):
+		return self._helpers

--- a/tracer/controllers/restart.py
+++ b/tracer/controllers/restart.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# restart.py
+# Defines RestartController
+#
+# Copyright (C) 2016 Benjamin Roberts
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+
+from tracer.resources.tracer import Tracer
+from tracer.resources.system import System
+from tracer.resources.rules import Rules
+from tracer.resources.applications import Applications
+from tracer.resources.memory import dump_memory
+from tracer.views.restart import RestartView
+import sys
+import os
+import subprocess
+
+
+class RestartController(object):
+
+	# Dictionary of Applications to True (restarted), False (failed to restart) and None (no restart helper)
+	restarted_daemons = None
+
+	def __init__(self, args, call_helper=None):
+		#TODO filter blacklisted packages from restart
+
+		tracer = Tracer(
+			System.package_manager(erased=args.erased),
+			Rules,
+			Applications,
+			memory=dump_memory,
+			erased=args.erased
+		)
+
+		daemons = tracer.trace_affected(user="root").filter_types([Applications.TYPES["DAEMON"]])
+
+		if call_helper is None:
+			call_helper = RestartController._call_helper
+		else:
+			call_helper = call_helper
+		self.restarted_daemons = RestartController.restart_daemons(daemons, call_helper)
+
+	def render(self):
+		view = RestartView()
+		view.assign("daemons", self.restarted_daemons)
+		view.render()
+
+		restart_failed = False in self.restarted_daemons.items()
+		RestartController._exit(restart_failed=restart_failed)
+
+	@staticmethod
+	def restart_daemons(daemons, call_helper):
+		"""
+		Iterate through the list of daemons and restart them by calling the first available helper.
+		Returns a dictionary of Applications to the result of their restart:
+			+ True: restart succeeded
+			+ False: restart failed
+			+ None: not restarted (no handler)
+		"""
+		restarted_daemons = {}
+		for daemon in daemons:
+			helpers = daemon.helpers()
+
+			if len(helpers) is 0:
+				restarted_daemons[daemon] = None
+			else:
+				helper = helpers[0]
+				if "sudo " in helper:
+					helper = helper.replace("sudo ", "")
+
+				restarted_daemons[daemon] = call_helper(helper)
+
+		return restarted_daemons
+
+	@staticmethod
+	def _call_helper(helper):
+		"""
+		Call the helper string in order to restart a daemon.
+		Exits if tracer is not running as root
+		"""
+		if os.geteuid() is not 0:
+			RestartController._exit(no_root=True)
+
+		with open(os.devnull, "w") as out:
+			return subprocess.call(helper.split(" "), stdout=out, stderr=out) is 0
+
+	@staticmethod
+	def _exit(no_root=False, restart_failed=False):
+		"""
+		0 - Daemons restarted successfully
+		201 - Not executed as root
+		202 - Daemon restart failed
+		"""
+		if no_root:
+			print("Must be root to restart daemons/services")
+			sys.exit(201)
+		elif restart_failed:
+			print("Failed to restart all restartable daemons")
+			sys.exit(202)
+		else:
+			sys.exit(0)
+
+
+
+
+

--- a/tracer/resources/args_parser.py
+++ b/tracer/resources/args_parser.py
@@ -114,6 +114,12 @@ parser.add_argument('--show-resource',
 	help='provide informations about selected resource'
 )
 
+parser.add_argument('--restart-daemons', '--restart-services',
+	dest='restart_daemons',
+	action='store_true',
+	help='restart daemons/services that are updated and restartable'
+)
+
 user = parser.add_mutually_exclusive_group()
 user.add_argument("-u", "--user",
 	nargs=1,

--- a/tracer/resources/router.py
+++ b/tracer/resources/router.py
@@ -47,6 +47,11 @@ class Router:
 			controller = ResourceController(self.args)
 			controller.render()
 
+		elif self.args.restart_daemons:
+			from tracer.controllers.restart import RestartController
+			controller = RestartController(self.args)
+			controller.render()
+
 		else:
 			from tracer.controllers.default import DefaultController
 			controller = DefaultController(self.args, self.packages)

--- a/tracer/views/restart.py
+++ b/tracer/views/restart.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# restart.py
+# Defines RestartView
+#
+# Copyright (C) 2016 Benjamin Roberts
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+
+from tracer.views import View
+from tracer.views.blocks import BlocksView
+
+
+class RestartView(View):
+
+	def render(self):
+
+		def get_content(filter_result):
+			return "\n".join(["	   " + daemon.name for daemon,result in self.args.daemons if result is filter_result])
+
+		blocks = [
+			{
+				"title": "  * These daemons/services have been restarted",
+				"content": get_content(True)
+			},
+			{
+				"title": "  * These daemons/services failed to be restarted",
+				"content": get_content(False)
+			},
+			{
+				"title": "  * These daemons/services must be manually restarted",
+				"content": get_content(None)
+			}
+		]
+
+		view = BlocksView(self.out)
+		view.assign("blocks", blocks)
+		view.render()


### PR DESCRIPTION
A new commandline switch "--restart-daemons/services" has been added to
restart any restartable daemons on the system.